### PR TITLE
Set argument parameters into stream defaults.

### DIFF
--- a/fft_analyzer.py
+++ b/fft_analyzer.py
@@ -32,12 +32,23 @@ class AudioStream():
                 self.cumulated_status |= status
                 return None
 
+        self.args = args
+        self.out_enable = False
+
+        sd.default.device = [args.input_dev, args.output_dev]
+        sd.default.channels = 2
+        sd.default.dtype = None
+        sd.default.latency = None
+        sd.default.samplerate = args.sample_rate
+        sd.default.blocksize = args.buff_size
+        sd.default.clip_off = True
+        sd.default.dither_off = args.dither
+        sd.default.never_drop_input = None
+        sd.default.prime_output_buffers_using_stream_callback = None
+
         # Checks will throw errors for invalid settings.
         sd.check_input_settings()
         sd.check_output_settings()
-
-        self.args = args
-        self.out_enable = False
 
         # Will store sounddevice status flags on buffer under/overflows, etc.
         self.cumulated_status = sd.CallbackFlags()
@@ -45,13 +56,7 @@ class AudioStream():
         self.out_sig = None
 
         # Create the stream
-        self.audio_stream = sd.Stream(callback=audio_callback,
-                                      channels=2,
-                                      device=[args.output_dev, args.input_dev],
-                                      samplerate=args.sample_rate,
-                                      blocksize=args.buff_size,
-                                      clip_off=True,
-                                      dither_off=args.dither)
+        self.audio_stream = sd.Stream(callback=audio_callback)
 
     def create_output_signal(self, freq=1000, level=-3, sig_type='sine'):
         '''Creates the array for global out_sig.


### PR DESCRIPTION
Fixes the issue of stream settings not being displayed correctly and of setting checks not being correctly verified until stream initialization.
